### PR TITLE
Fix for issue 57

### DIFF
--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -166,8 +166,12 @@ module Toto
       end
 
       def render page, type
-        content = to_html page, @config
-        type == :html ? to_html(:layout, @config, &Proc.new { content }) : send(:"to_#{type}", page)
+        if type == :html
+          content = to_html page, @config
+          to_html(:layout, @config, &Proc.new { content })
+        else
+          send(:"to_#{type}", page)
+        end
       end
 
       def to_xml page

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -97,7 +97,8 @@ module Toto
       self[:root]
     end
 
-    def go route, type = :html, env
+    def go route, type, env
+      type ||= :html
       route << self./ if route.empty?
       type, path = type =~ /html|xml|json/ ? type.to_sym : :html, route.join('/')
       context = lambda do |data, page|
@@ -335,7 +336,7 @@ module Toto
       path, mime = @request.path_info.split('.')
       route = (path || '/').split('/').reject {|i| i.empty? }
 
-      response = @site.go(route, *(mime ? mime : []), env)
+      response = @site.go(route, mime ? mime : [], env)
 
       @response.body = [response[:body]]
       @response['Content-Length'] = response[:body].length.to_s unless response[:body].empty?

--- a/test/templates/custom.builder
+++ b/test/templates/custom.builder
@@ -1,0 +1,10 @@
+xml.instruct!
+xml.custom do
+  xml.title @config[:title]
+  xml.id @config[:url]
+
+  xml.child do
+    xml.name "Testing Baby"
+  end
+end
+

--- a/test/toto_test.rb
+++ b/test/toto_test.rb
@@ -102,6 +102,13 @@ context Toto do
     asserts("summary shouldn't be empty")   { topic.body }.includes_html("summary" => /.{10,}/)
   end
 
+  context "GET /custom.xml (custom XML)" do
+    setup { @toto.get('/custom.xml') }
+    asserts("content type is set properly") { topic.content_type }.equals "application/xml"
+    asserts("body should be valid xml")     { topic.body }.includes_html("custom > child" => /.+/)
+    asserts("summary shouldn't be empty")   { topic.body }.includes_html("name" => /.{10,}/)
+  end
+
   context "GET to a repo name" do
     setup do
       class Toto::Repo


### PR DESCRIPTION
Hey Cloudhead,

When adding a `*.builder` file to the `templates` directory the file is not picked up (it gives a 404) unless you also create a `*.rhtml` file in the `pages` directory. This was due to a little bug in the `render` method. 

I've committed a change in myt `issue_57` branch that tackles this problem. I've also added a test for it. 

Hope you could pull this in for the next release of Toto. 

Regards, 
Ariejan de Vroom
ariejan@ariejan.net
