### PR TITLE
JRuby support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ begin
     gem.add_development_dependency "riot"
     gem.add_dependency "builder"
     gem.add_dependency "rack"
-    if RUBY_PLATFORM =~ /win32/
+    if RUBY_PLATFORM =~ /win32|java/
       gem.add_dependency "maruku"
     else
       gem.add_dependency "rdiscount"

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -5,9 +5,8 @@ require 'rack'
 require 'digest'
 require 'open-uri'
 
-if RUBY_PLATFORM =~ /win32/
+if RUBY_PLATFORM =~ /win32|java/
   require 'maruku'
-  Markdown = Maruku
 else
   require 'rdiscount'
 end
@@ -41,7 +40,11 @@ module Toto
 
     def markdown text
       if (options = @config[:markdown])
-        Markdown.new(text.to_s.strip, *(options.eql?(true) ? [] : options)).to_html
+        if RUBY_PLATFORM =~ /win32|java/
+          Maruku.new(text.to_s.strip).to_html
+        else
+          Markdown.new(text.to_s.strip, *(options.eql?(true) ? [] : options)).to_html
+        end
       else
         text.strip
       end


### PR DESCRIPTION
Toto is great!  I wanted to run toto under a bare JRuby rackup, which generally just seems to need the maruku support already added in for Win32.  The first of the 2 commits in this fork does that.  But I was not able to get maruku to work with the same option passing behavior as Markdown, so the second commit disables it; this might be a bad idea; at least it could be done prettier.  But it worked, and Dorothy's been deployed to an app server.  Let me know if there is anything else I can do to get JRuby support included upstream.  Thanks!
