### PR TITLE
Friendly display of article having a damaged "front matter"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ end
 
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
+  test.libs << 'lib' << 'test' << '.'
   test.pattern = 'test/**/*_test.rb'
   test.verbose = true
 end

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -232,7 +232,7 @@ module Toto
 
         # use the date from the filename, or else toto won't find the article
         @obj =~ /\/(\d{4}-\d{2}-\d{2})[^\/]*$/
-        ($1 ? {:date => $1} : {}).merge(YAML.load(meta))
+        ($1 ? {:date => $1} : {}).merge(load_front(meta))
       elsif @obj.is_a? Hash
         @obj
       end.inject({}) {|h, (k,v)| h.merge(k.to_sym => v) }
@@ -280,6 +280,12 @@ module Toto
     def author()  self[:author] || @config[:author]          end
     def to_html() self.load; super(:article, @config)        end
     alias :to_s to_html
+    
+    private
+    def load_front(meta)
+      matter = YAML.load(meta)
+      matter.is_a?(Hash) ? matter : {:title => @obj.to_s, :body => "Failed to parse front matter : #{meta}"}
+    end
   end
 
   class Config < Hash

--- a/test/articles/2011-01-24-damage.txt
+++ b/test/articles/2011-01-24-damage.txt
@@ -1,0 +1,3 @@
+front matter is missing!!!
+
+## this is a mere recipe in markdown

--- a/test/toto_test.rb
+++ b/test/toto_test.rb
@@ -51,7 +51,7 @@ context Toto do
     setup { @toto.get('/about') }
     asserts("returns a 200")                { topic.status }.equals 200
     asserts("body is not empty")            { not topic.body.empty? }
-    should("have access to @articles")      { topic.body }.includes_html("#count" => /5/)
+    should("have access to @articles")      { topic.body }.includes_html("#count" => /6/)
   end
 
   context "GET a single article" do

--- a/test/toto_test.rb
+++ b/test/toto_test.rb
@@ -241,6 +241,15 @@ context Toto do
 
         should("be in the directory") { topic.path }.equals Date.today.strftime("/blog/%Y/%m/%d/toto-and-the-wizard-of-oz/")
       end
+      
+      context "damaged article" do
+        setup do
+          conf = Toto::Config.new({})
+          damaged = File.expand_path('../articles/2011-01-24-damage.txt', __FILE__)
+          Toto::Article.new(damaged, conf)
+        end
+        should("load with a damaged body") {topic.load[:body]}.matches(/^Failed to parse front matter/)
+      end
     end
   end
 

--- a/toto.gemspec
+++ b/toto.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
      "test/articles/2009-04-01-tilt-factor.txt",
      "test/articles/2009-12-04-some-random-article.txt",
      "test/articles/2009-12-11-the-dichotomy-of-design.txt",
+     "test/articles/2011-01-24-damage.txt",
      "test/autotest.rb",
      "test/templates/about.rhtml",
      "test/templates/archives.rhtml",


### PR DESCRIPTION
Hello !

Having a damaged file under /articles prevents site from displaying '/'

```
TypeError at /
can't convert String into Hash
```
# Damaged?

By damaged, I mean front matter does not parse to Hash using YAML.load

(I had a quick search on ticket 'convert' keyword, and did not find)

So here is a topic branch for this functionality
# Why do I think it is useful ?

One mistake means no site

I made a demo with such an article ... (git checkout saved me after 30s of bewilderment)
# What may be better ?

reduce list of article to undamaged articles (ignore damaged article)

Cheers
