### PR TITLE
Add Summary Suffix

### DIFF
--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -254,12 +254,13 @@ module Toto
 
     def summary length = nil
       config = @config[:summary]
+      config[:suffix] ||= Config::Defaults[:summary][:suffix]
       sum = if self[:body] =~ config[:delim]
         self[:body].split(config[:delim]).first
       else
         self[:body].match(/(.{1,#{length || config[:length] || config[:max]}}.*?)(\n|\Z)/m).to_s
       end
-      markdown(sum.length == self[:body].length ? sum : sum.strip.sub(/\.\Z/, '&hellip;'))
+      markdown(sum.length == self[:body].length ? sum : sum.strip.sub(/\.\Z/, config[:suffix].call(self)))
     end
 
     def url
@@ -292,7 +293,7 @@ module Toto
       :date => lambda {|now| now.strftime("%d/%m/%Y") },    # date function
       :markdown => :smart,                                  # use markdown
       :disqus => false,                                     # disqus name
-      :summary => {:max => 150, :delim => /~\n/},           # length of summary and delimiter
+      :summary => {:max => 150, :delim => /~\n/, :suffix => lambda {|article| "&hellip;" }}, # length of summary, delimiter and what to suffix
       :ext => 'txt',                                        # extension for articles
       :cache => 28800,                                      # cache duration (seconds)
       :github => {:user => "", :repos => [], :ext => 'md'}, # Github username and list of repos

--- a/test/toto_test.rb
+++ b/test/toto_test.rb
@@ -190,6 +190,20 @@ context Toto do
 
       context "and long first paragraph" do
         should("create a valid summary") { topic.summary }.equals "<p>" + ("a little bit of text." * 5).chop + "&hellip;</p>\n"
+
+        context "and a custom summary suffix" do
+          setup do
+            Toto::Article.new({
+              :title  => "The Wizard of Oz",
+              :body   => ("a little bit of text." * 5) + "\n" + "filler" * 10,
+              :date   => "19/10/1976",
+              :slug   => "wizard-of-oz",
+              :author => "toetoe"
+            }, @config.merge(:summary => {:length => 50, :suffix => lambda {|article| "More: " + article.author }}))
+          end
+          
+          should("suffix the summary with the custom lambda") { topic.summary }.matches(/More: toetoe<\/p>\n$/)
+       end
       end
 
       context "and a short first paragraph" do

--- a/test/toto_test.rb
+++ b/test/toto_test.rb
@@ -1,4 +1,4 @@
-require 'test/test_helper'
+require File.expand_path File.join(File.dirname(__FILE__), 'test_helper')
 require 'date'
 
 URL = "http://toto.oz"


### PR DESCRIPTION
In my template I wanted my read more link to sit within the same <p> tag as the summary text so one leads on from the other however I found this to be impossible as the suffix append to the summary text (the ellipsis) was hard coded. I am unable to change this within my template as the <p> tag I am referring to is generated as part of the summary text generated using markdown.

This patch adds an additional item to config[:summary] named :suffix which allows the user to customise the suffix by defining a lambda. By default the output remains an ellipsis.

Example setting of a custom suffix solving my "read more link in the summary" use-case:

```
set :summary,   :max => 150, :delim => /~/, :suffix => lambda {|article| "&hellip; <a class='article-readmore' href='#{article.path}'>Read More</a>" }
```
