### PR TITLE
Added baseurl method to the context

### DIFF
--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -178,6 +178,10 @@ module Toto
       def method_missing m, *args, &blk
         @context.respond_to?(m) ? @context.send(m, *args, &blk) : super
       end
+
+      def baseurl
+        'http://' + (@config[:url].sub("http://", '') + '/' + @config[:prefix]).squeeze('/')
+      end
     end
   end
 

--- a/test/templates/index.rhtml
+++ b/test/templates/index.rhtml
@@ -11,3 +11,5 @@
 <!-- testing get/post parameter passing -->
 <p>request method type: <%= env['REQUEST_METHOD'] %><br/></p>
 <p>request name value pair: <%= env['QUERY_STRING'] %><br/></p>
+<!-- testing baseurl -->
+<p>baseurl: <%= baseurl %></p>

--- a/test/toto_test.rb
+++ b/test/toto_test.rb
@@ -110,6 +110,11 @@ context Toto do
     asserts("access the http parameter name value pair")           { topic.body }.includes_html("p" => /request name value pair: param=testparam/)
   end
 
+  context "GET / (baseurl)" do
+    setup { @toto.get('/')   }
+    asserts("access the http get parameter") { topic.body }.includes_html("p" => %r{baseurl: #{URL}})
+  end
+
 
 
   context "GET to a repo name" do


### PR DESCRIPTION
This simple method allows for example

``` rhtml
<!-- file: layout.rhtml -->
<html>
  <head>
    <base href="<%= baseurl %>" />
  </head>
</html>
```

Probably it's not the most useful feature - I used it for links in HTML comments for incoming hackers. But generally it's probably useless crap :))
