### PR TITLE
Correctly set Content-Length when using Ruby 1.9

### DIFF
--- a/lib/ext/ext.rb
+++ b/lib/ext/ext.rb
@@ -14,6 +14,12 @@ class String
   def humanize
     self.capitalize.gsub(/[-_]+/, ' ')
   end
+
+  if RUBY_VERSION < "1.9"
+    def bytesize
+      size
+    end
+  end
 end
 
 class Fixnum

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -338,7 +338,7 @@ module Toto
       response = @site.go(route, env, *(mime ? mime : []))
 
       @response.body = [response[:body]]
-      @response['Content-Length'] = response[:body].length.to_s unless response[:body].empty?
+      @response['Content-Length'] = response[:body].bytesize.to_s unless response[:body].empty?
       @response['Content-Type']   = Rack::Mime.mime_type(".#{response[:type]}")
 
       # Set http cache headers


### PR DESCRIPTION
The meaning of String#length changed between 1.8 and 1.9. This commit clarifies that Content-Length is the number of bytes, and monkey-patches String#bytesize into 1.8.

I think the default setup for Heroku is now Ruby 1.9, so it makes sense to ensure that Toto works with it.

See #91, #86, etc.
