### PR TITLE
Article date in URL point to today's date if there is a valid date in the article metadata

### DIFF
--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -239,7 +239,9 @@ module Toto
 
       self.taint
       self.update data
-      self[:date] = Date.parse(self[:date].gsub('/', '-')) rescue Date.today
+      unless self[:date].is_a? Date
+        self[:date] = Date.parse(self[:date].gsub('/', '-')) rescue Date.today
+      end
       self
     end
 

--- a/test/articles/2011-08-01-with-a-valid-date-not-today.txt
+++ b/test/articles/2011-08-01-with-a-valid-date-not-today.txt
@@ -1,0 +1,4 @@
+title: With a valid date not today
+date: 2011-08-01
+
+If the metadata contains a valid date the YAML.load call with parse the date into an actual datetime object.

--- a/test/toto_test.rb
+++ b/test/toto_test.rb
@@ -47,11 +47,19 @@ context Toto do
     end
   end
 
+  context "links to proper loaded article date and not today" do
+    setup do
+      Toto::Article.new("test/articles/2011-08-01-with-a-valid-date-not-today.txt", @config)
+    end
+
+    asserts("url points to the actual file date") { topic.url }.equals "#{URL}/2011/08/01/with-a-valid-date-not-today/"
+  end
+
   context "GET /about" do
     setup { @toto.get('/about') }
     asserts("returns a 200")                { topic.status }.equals 200
     asserts("body is not empty")            { not topic.body.empty? }
-    should("have access to @articles")      { topic.body }.includes_html("#count" => /5/)
+    should("have access to @articles")      { topic.body }.includes_html("#count" => /6/)
   end
 
   context "GET a single article" do


### PR DESCRIPTION
Hi,

I had (without thinking about it) created an article that had the date in a parseable form ( for example "2011-08-01" rather than "01/08/2011"). What was happening was that the article url (for example from the home page) had today's date in the url. For example article date was 2011-08-01, however article url was /2011/08/04- (today) - obviously clicking this link took you to a 404.

I added a test and narrowed down the problem to line 242 in toto.rb. It seems when there is a valid date, the yaml loader parses it into an actual Date instance rather than keeping it as a string. This means an exception is thrown since Date doesn't have the gsub method so it defaults to today.

The quick fix I added was to add a check to see if the :date was already a Date.

Although this came about from my mistake (so you may not want this fix) - it was really annoying to track down so I would be really keen at getting some kind of warning/error when this happens to appear in the logs or something. Happy to do this work - just let me know.

Also, I note that in the file, there is a comment "use the date from the filename, or else toto won't find the article" - however it doesn't do this. The #merge at line 253 overrides whatever came from the filename regex with what is in the "meta" block. If the meta block's date is out of sync with what the filename actually is you will get links to nowhere. So maybe this needs a bit of a tidy up/clarification - again happy to help out.

Thanks!
