### PR TITLE
Privatizable

### DIFF
--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -19,7 +19,7 @@ $:.unshift File.dirname(__FILE__)
 require 'ext/ext'
 
 module Toto
-  DRAFT_RE = /^~DRAFT~/
+  DRAFT_RE = /^~DRAFT~ /
   DRAFT_ENV = 'development'
 
   Paths = {

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -162,7 +162,7 @@ module Toto
           Article.new(a, @config)
         end
 
-        if DRAFT_ENV != Toto.env
+        unless DRAFT_ENV == Toto.env
           @articles.reject!{ |a| a.title.match(DRAFT_RE) }
         end
 

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -260,7 +260,7 @@ module Toto
     end
 
     def slug
-      self[:slug] || self[:title].slugize
+      self[:slug] || self[:title].gsub(DRAFT_RE, '').slugize
     end
 
     def summary length = nil

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -19,6 +19,9 @@ $:.unshift File.dirname(__FILE__)
 require 'ext/ext'
 
 module Toto
+  DRAFT_RE = /^~DRAFT~/
+  DRAFT_ENV = 'development'
+
   Paths = {
     :templates => "templates",
     :pages => "templates/pages",
@@ -75,6 +78,8 @@ module Toto
       articles = type == :html ? self.articles.reverse : self.articles
       {:articles => articles.map do |article|
         Article.new article, @config
+      end.reject do |article|
+        DRAFT_ENV != Toto.env && article.title.match(DRAFT_RE)
       end}.merge archives
     end
 
@@ -84,6 +89,8 @@ module Toto
           filter !~ /^\d{4}/ || File.basename(a) =~ /^#{filter}/
         end.reverse.map do |article|
           Article.new article, @config
+        end.reject do |article|
+          DRAFT_ENV != Toto.env && article.title.match(DRAFT_RE)
         end : []
 
       return :archives => Archives.new(entries, @config)
@@ -153,6 +160,10 @@ module Toto
         @config, @context, @path, @env = config, ctx, path, env
         @articles = Site.articles(@config[:ext]).reverse.map do |a|
           Article.new(a, @config)
+        end
+
+        if DRAFT_ENV != Toto.env
+          @articles.reject!{ |a| a.title.match(DRAFT_RE) }
         end
 
         ctx.each do |k, v|

--- a/test/articles/2011-08-07-the-beautiful-people.txt
+++ b/test/articles/2011-08-07-the-beautiful-people.txt
@@ -1,0 +1,5 @@
+title: ~DRAFT~ the wizard of oz
+date: 12/10/1932
+
+Once upon a time...
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,21 @@ module Toto
     end
   end
 
+  class NotIncludesHTMLMacro < Riot::AssertionMacro
+    register :not_includes_html
+
+    def evaluate(actual, expected)
+      expected = expected.to_a.flatten
+      data = Hpricot.parse(actual)/expected.first
+
+      if !data.empty? and data.inner_html.match(expected.last)
+        fail("expected <#{expected.first}> to contain no #{expected.last}")
+      else
+        pass
+      end
+    end
+  end
+
   class IncludesElementsMacro < Riot::AssertionMacro
     register :includes_elements
 

--- a/test/toto_test.rb
+++ b/test/toto_test.rb
@@ -1,4 +1,4 @@
-require 'test/test_helper'
+require 'test_helper'
 require 'date'
 
 URL = "http://toto.oz"

--- a/test/toto_test.rb
+++ b/test/toto_test.rb
@@ -282,11 +282,9 @@ context Toto do
   end
 
   context "on non-development environment" do
-    Toto.env = 'production'
-
     context "GET /" do
       setup { @toto.get('/') }
-      should("do not include ~DRAFT~ articles") { topic.body }.not_includes_html("li" => /~DRAFT~/)
+      should("not include ~DRAFT~ articles") { topic.body }.not_includes_html("li" => /~DRAFT~/)
     end
 
     context "GET a ~DRAFT~ article" do
@@ -298,10 +296,12 @@ context Toto do
   end
 
   context "on development environment" do
-    Toto.env = 'development'
-
     context "GET /" do
-      setup { @toto.get('/') }
+      setup do
+        Toto.env = 'development'
+        @toto.get('/')
+      end
+
       should("include ~DRAFT~ articles") { topic.body }.includes_html("li" => /~DRAFT~/)
     end
   end

--- a/test/toto_test.rb
+++ b/test/toto_test.rb
@@ -280,6 +280,31 @@ context Toto do
   context "extensions to the core Ruby library" do
     should("respond to iso8601") { Date.today }.respond_to?(:iso8601)
   end
+
+  context "on non-development environment" do
+    Toto.env = 'production'
+
+    context "GET /" do
+      setup { @toto.get('/') }
+      should("do not include ~DRAFT~ articles") { topic.body }.not_includes_html("li" => /~DRAFT~/)
+    end
+
+    context "GET a ~DRAFT~ article" do
+      setup { @toto.get("/2011/08/07/the-beautiful-people") }
+      asserts("returns a 200")                { topic.status }.equals 200
+      asserts("content type is set properly") { topic.content_type }.equals "text/html"
+      should("contain the article")           { topic.body }.includes_html("h2" => /~DRAFT~/)
+    end
+  end
+
+  context "on development environment" do
+    Toto.env = 'development'
+
+    context "GET /" do
+      setup { @toto.get('/') }
+      should("include ~DRAFT~ articles") { topic.body }.includes_html("li" => /~DRAFT~/)
+    end
+  end
 end
 
 


### PR DESCRIPTION
This patch allows to "hide" articles with `~DRAFT~` prefix of title from the list of articles/archives. This is useful when you want to commit "draft" version of article, but don't want it to appear in the lists (atom feed, index page, archives).

Not sure will you find it useful or not (I assume this might seems great only for me), but anyway it has tests and it works for me, so now I don't need to have "draft" branch in local repo, or "keep an eye" on what to commit and what not - I just commit not finished posts as drafts, and even if my public server will pull all articles, draft ones won't "break" my atom feed or index page :))
