### PR TITLE
Added url suffix option 

### DIFF
--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -94,6 +94,7 @@ module Toto
       cats = Array.new
       entries.each { |i|
         cat = (i.category!=nil) ? i.category : ''
+        puts cat
         cats = cats | cat.split('/')
       }
       return cats
@@ -103,7 +104,13 @@ module Toto
       articles = self.index
       Article.new("#{Paths[:articles]}/#{route.join('-')}.#{self[:ext]}", @config).load(articles)
     end
-
+    
+    def category route
+      index
+    end
+    def tag
+      index
+    end
     def /
       self[:root]
     end
@@ -128,8 +135,11 @@ module Toto
               context[article(route), :article]
             else http 400
           end
-        elsif respond_to?(path)
+        elsif respond_to?(path) 
           context[send(path, type), path.to_sym]
+        elsif respond_to?(path.split('/').first)
+          m = path.split('/').first 
+          context[archives(route * '-'), m]
         elsif (repo = @config[:github][:repos].grep(/#{path}/).first) &&
               !@config[:github][:user].empty?
           context[Repo.new(repo, @config), :repo]
@@ -157,7 +167,7 @@ module Toto
     end
 
     def self.articles ext
-      Dir["#{Paths[:articles]}/*.#{ext}"].sort_by {|entry| File.basename(entry) }
+      Dir["#{Paths[:articles]}/*.#{ext}"].sort_by {|entry| test(?M ,entry) }
     end
 
     class Context
@@ -380,3 +390,4 @@ module Toto
     end
   end
 end
+

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -24,7 +24,7 @@ module Toto
     :pages => "templates/pages",
     :articles => "articles"
   }
-
+ 
   def self.env
     ENV['RACK_ENV'] || 'production'
   end

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -359,5 +359,26 @@ module Toto
       @response.finish
     end
   end
+  class Route
+    attr_accessor :name,:regex
+    def initialize name,regex
+      @name   = name
+      @regex  = regex
+    end
+  end
+  class Router
+    def initialize
+      @routes = Array.new
+    end
+    def add_route route
+      @routes.push(route)
+    end
+    def match_route path
+      @routes.each do |route|
+        return route if(path =~ route.regex)
+      end
+      return nil
+    end
+  end
 end
 

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -103,7 +103,6 @@ module Toto
       context = lambda do |data, page|
         Context.new(data, @config, path, env).render(page, type)
       end
-
       body, status = if Context.new.respond_to?(:"to_#{type}")
         if route.first =~ /\d{4}/
           case route.size
@@ -272,7 +271,11 @@ module Toto
     end
 
     def path
-      "/#{@config[:prefix]}#{self[:date].strftime("/%Y/%m/%d/#{slug}/")}".squeeze('/')
+      if(@config[:suffix]=='/')
+        return "/#{@config[:prefix]}#{self[:date].strftime("/%Y/%m/%d/#{slug}/")}".squeeze('/')
+      else
+        return "/#{@config[:prefix]}#{self[:date].strftime("/%Y/%m/%d/#{slug}/")}".squeeze('/').chomp('/') + @config[:suffix]
+      end
     end
 
     def title()   self[:title] || "an article"               end
@@ -301,7 +304,8 @@ module Toto
       },
       :error => lambda {|code|                              # The HTML for your error page
         "<font style='font-size:300%'>toto, we're not in Kansas anymore (#{code})</font>"
-      }
+      },
+      :suffix => '/'
     }
     def initialize obj
       self.update Defaults
@@ -338,6 +342,7 @@ module Toto
       response = @site.go(route, env, *(mime ? mime : []))
 
       @response.body = [response[:body]]
+      @response.body << mime
       @response['Content-Length'] = response[:body].length.to_s unless response[:body].empty?
       @response['Content-Type']   = Rack::Mime.mime_type(".#{response[:type]}")
 

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -107,7 +107,14 @@ module Toto
         if route.first =~ /\d{4}/
           case route.size
             when 1..3
-              context[archives(route * '-'), :archives]
+              last_item = Integer(route.last) rescue route.last
+              if(last_item.is_a? Fixnum)
+                puts route.last + route.last.class.to_s + ":archives"
+                context[archives(route * '-'), :archives]
+              else
+                puts route.last + route.last.class.to_s + ":article"
+                context[article(route), :article]
+              end
             when 4
               context[article(route), :article]
             else http 400
@@ -272,9 +279,9 @@ module Toto
 
     def path
       if(@config[:suffix]=='/')
-        return "/#{@config[:prefix]}#{self[:date].strftime("/%Y/%m/%d/#{slug}/")}".squeeze('/')
+        return "/#{@config[:prefix]}#{self[:date].strftime("/%Y/%m/#{slug}/")}".squeeze('/')
       else
-        return "/#{@config[:prefix]}#{self[:date].strftime("/%Y/%m/%d/#{slug}/")}".squeeze('/').chomp('/') + @config[:suffix]
+        return "/#{@config[:prefix]}#{self[:date].strftime("/%Y/%m/#{slug}/")}".squeeze('/').chomp('/') + @config[:suffix]
       end
     end
 

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -109,10 +109,8 @@ module Toto
             when 1..3
               last_item = Integer(route.last) rescue route.last
               if(last_item.is_a? Fixnum)
-                puts route.last + route.last.class.to_s + ":archives"
                 context[archives(route * '-'), :archives]
               else
-                puts route.last + route.last.class.to_s + ":article"
                 context[article(route), :article]
               end
             when 4
@@ -312,7 +310,8 @@ module Toto
       :error => lambda {|code|                              # The HTML for your error page
         "<font style='font-size:300%'>toto, we're not in Kansas anymore (#{code})</font>"
       },
-      :suffix => '/'
+      :suffix => '/',
+      :dateformat => '%Y/%m/%d'
     }
     def initialize obj
       self.update Defaults

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -279,9 +279,9 @@ module Toto
 
     def path
       if(@config[:suffix]=='/')
-        return "/#{@config[:prefix]}#{self[:date].strftime("/%Y/%m/#{slug}/")}".squeeze('/')
+        return "/#{@config[:prefix]}#{self[:date].strftime("/#{@config[:dateformat]}/#{slug}/")}".squeeze('/')
       else
-        return "/#{@config[:prefix]}#{self[:date].strftime("/%Y/%m/#{slug}/")}".squeeze('/').chomp('/') + @config[:suffix]
+        return "/#{@config[:prefix]}#{self[:date].strftime("/#{@config[:dateformat]}/#{slug}/")}".squeeze('/').chomp('/') + @config[:suffix]
       end
     end
 

--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -365,26 +365,4 @@ module Toto
       @response.finish
     end
   end
-  class Route
-    attr_accessor :name,:regex
-    def initialize name,regex
-      @name   = name
-      @regex  = regex
-    end
-  end
-  class Router
-    def initialize
-      @routes = Array.new
-    end
-    def add_route route
-      @routes.push(route)
-    end
-    def match_route path
-      @routes.each do |route|
-        return route if(path =~ route.regex)
-      end
-      return nil
-    end
-  end
 end
-


### PR DESCRIPTION
When I tried to port my wordpress blog to toto, the url format became a problem for me, where all my urls ended with .html and toto (as I believed) didn't support custom urls. So I changed the path in such a way that it can have any extensions
# note

Added additional property for url suffix in config class.
