### PR TITLE
Malformed RSS XML file on Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,10 @@ Toto was designed to work well with [heroku](http://heroku.com), it makes the mo
 by setting the _Cache-Control_ and _Etag_ HTTP headers. Deploying on Heroku is really easy, just get the heroku gem,
 create a heroku app with `heroku create`, and push with `git push heroku master`.
 
-    $ heroku create weblog
+    $ heroku create weblog --stack bamboo-ree-1.8.7 
     $ git push heroku master
     $ heroku open
+
 
 ### configuration
 


### PR DESCRIPTION
When deploying a toto app on Heroku, errors might appear on the rss.xml file. 

I appears the problem is the Heroku stack used to deploy the app. It should run on the bamboo 1.8.7 stack and not the bamboo 1.9.2 that is the default one. 

For existing apps you can migrate easily doing the following : 

```
heroku stack:migrate bamboo-ree-1.8.7
```

For new apps, you can use the following : 

```
heroku create --stack bamboo-ree-1.8.7 
```
