### PR TITLE
Allow for custom date formats in articles

### DIFF
--- a/lib/toto.rb
+++ b/lib/toto.rb
@@ -239,7 +239,7 @@ module Toto
 
       self.taint
       self.update data
-      self[:date] = Date.parse(self[:date].gsub('/', '-')) rescue Date.today
+      self[:date] = Date.strptime(self[:date], self[:date] =~ /-/ ? "%Y-%m-%d" : @config[:date_format]) rescue Date.today
       self
     end
 
@@ -290,6 +290,7 @@ module Toto
       :url => "http://127.0.0.1",                           # root URL of the site
       :prefix => "",                                        # common path prefix for the blog
       :date => lambda {|now| now.strftime("%d/%m/%Y") },    # date function
+      :date_format => "%d/%m/%Y",                           # date format
       :markdown => :smart,                                  # use markdown
       :disqus => false,                                     # disqus name
       :summary => {:max => 150, :delim => /~\n/},           # length of summary and delimiter

--- a/test/toto_test.rb
+++ b/test/toto_test.rb
@@ -201,6 +201,18 @@ context Toto do
       end
     end
 
+    context "with a date specified in US format" do
+      setup do
+        conf = Toto::Config.new({})
+        conf.set(:date_format, "%m/%d/%Y")
+        Toto::Article.new({
+          :date => "01/31/2012"
+        }, conf)
+      end
+
+      should("parse the date") { [topic[:date].month, topic[:date].day, topic[:date].year] }.equals [1, 31, 2012]
+    end
+
     context "in a subdirectory" do
       context "with implicit leading forward slash" do
         setup do
@@ -241,6 +253,14 @@ context Toto do
         should("be in the directory") { topic.path }.equals Date.today.strftime("/blog/%Y/%m/%d/toto-and-the-wizard-of-oz/")
       end
     end
+  end
+
+  context "with an existing article" do
+    setup do
+      Toto::Article.new("#{File.dirname(__FILE__)}/articles/2009-12-04-some-random-article.txt", Toto::Config::Defaults)
+    end
+
+    should("pick up the date correctly") { [topic[:date].month, topic[:date].day, topic[:date].year] }.equals [10, 12, 1932]
   end
 
   context "using Config#set with a hash" do

--- a/test/toto_test.rb
+++ b/test/toto_test.rb
@@ -19,7 +19,7 @@ context Toto do
     asserts("returns a 200")                { topic.status }.equals 200
     asserts("body is not empty")            { not topic.body.empty? }
     asserts("content type is set properly") { topic.content_type }.equals "text/html"
-    should("include a couple of article")   { topic.body }.includes_elements("#articles li", 3)
+    should("include a couple of articles")   { topic.body }.includes_elements("#articles li", 3)
     should("include an archive")            { topic.body }.includes_elements("#archives li", 2)
 
     context "with no articles" do
@@ -101,6 +101,7 @@ context Toto do
     asserts("body should be valid xml")     { topic.body }.includes_html("feed > entry" => /.+/)
     asserts("summary shouldn't be empty")   { topic.body }.includes_html("summary" => /.{10,}/)
   end
+
   context "GET /index?param=testparam (get parameter)" do
     setup { @toto.get('/index?param=testparam')   }
     asserts("returns a 200")                { topic.status }.equals 200
@@ -109,8 +110,6 @@ context Toto do
     asserts("access the http get parameter")           { topic.body }.includes_html("p" => /request method type: GET/)
     asserts("access the http parameter name value pair")           { topic.body }.includes_html("p" => /request name value pair: param=testparam/)
   end
-
-
 
   context "GET to a repo name" do
     setup do
@@ -281,5 +280,3 @@ context Toto do
     should("respond to iso8601") { Date.today }.respond_to?(:iso8601)
   end
 end
-
-


### PR DESCRIPTION
I am accustomed to dates in the mm/dd/yyyy format. This change allows for specifying `:date_format` in the rackup config when creating a server. So for example if my Rakefile is changed to include a date like `article = {'title' => title, 'date' => Time.now.strftime("%m/%d/%Y")}.to_yaml` (as in Dorothy), I can parse it correctly with specifying `set :date_format, "%m/%d/%Y"`.

Thanks for creating such a concise blog engine!
